### PR TITLE
Shorten Rails workflow name, in line with others

### DIFF
--- a/ci/properties/rubyonrails.properties.json
+++ b/ci/properties/rubyonrails.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Ruby on Rails continuous integration",
+    "name": "Ruby on Rails",
     "description": "Build, lint, and test a Rails application",
     "iconName": "rails",
     "categories": ["Continuous integration", "Ruby", "Rails"]


### PR DESCRIPTION
The workflows for Ruby, RubyGem, Jekyll, and similar are all just the name of the language, package, or framework. This name change brings the Rails workflow card in line with the other starters.
